### PR TITLE
skip images with no matching target versions

### DIFF
--- a/pkg/overwrite.go
+++ b/pkg/overwrite.go
@@ -380,7 +380,8 @@ func (io *imageOverwrite) parseGenericImages(ctx context.Context, ca *cdv2.Compo
 			return nil, err
 		}
 		if len(entries) == 0 {
-			return nil, fmt.Errorf("no corresponding resource found for %s", image.Name)
+			io.log.V(1).Info("no image for target version found", "image", image.Name, "targetVersion", image.TargetVersion)
+			continue
 		}
 		images = append(images, entries...)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

Skip images for not supported kubernetes versions.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Skip images for not supported kubernetes versions.
```
