### PR TITLE
Prevent loss of target value label

### DIFF
--- a/pkg/imagevector.go
+++ b/pkg/imagevector.go
@@ -312,10 +312,43 @@ func (ip *imageParser) Parse(ctx context.Context, image ImageEntry) error {
 	// add resource
 	id := ip.cd.GetResourceIndex(res)
 	if id != -1 {
+		if err := preventLossOfTargetVersionLabel(&ip.cd.Resources[id], &res); err != nil {
+			return err
+		}
+
 		ip.cd.Resources[id] = cdutils.MergeResources(ip.cd.Resources[id], res)
 	} else {
 		ip.cd.Resources = append(ip.cd.Resources, res)
 	}
+	return nil
+}
+
+// preventLossOfTargetVersionLabel throws an error if the provided resources both have a target version label
+// with different values. In this case, one of the labels would get lost if the resources are merged.
+func preventLossOfTargetVersionLabel(res1, res2 *cdv2.Resource) error {
+	var (
+		targetVersion1 string
+		targetVersion2 string
+	)
+
+	hasLabel1, err := getLabel(res1.Labels, TargetVersionLabel, &targetVersion1)
+	if err != nil {
+		return err
+	}
+
+	hasLabel2, err := getLabel(res2.Labels, TargetVersionLabel, &targetVersion2)
+	if err != nil {
+		return err
+	}
+
+	if hasLabel1 && hasLabel2 && targetVersion1 != targetVersion2 {
+		tag := res2.IdentityObjectMeta.GetIdentity()[TagExtraIdentity]
+		return fmt.Errorf(`there is more than one image entry with name %q and tag %q. `+
+			`Only one entry for the same name-tag combination is supported. A solution might be to combine `+
+			`entries by using a range of target versions, for example: targetVersion: ">= 1.18, < 1.22"`,
+			res2.Name, tag)
+	}
+
 	return nil
 }
 

--- a/pkg/imagevector.go
+++ b/pkg/imagevector.go
@@ -343,9 +343,10 @@ func preventLossOfTargetVersionLabel(res1, res2 *cdv2.Resource) error {
 
 	if hasLabel1 && hasLabel2 && targetVersion1 != targetVersion2 {
 		tag := res2.IdentityObjectMeta.GetIdentity()[TagExtraIdentity]
-		return fmt.Errorf(`there is more than one image entry with name %q and tag %q. `+
-			`Only one entry for the same name-tag combination is supported. A solution might be to combine `+
-			`entries by using a range of target versions, for example: targetVersion: ">= 1.18, < 1.22"`,
+
+		return fmt.Errorf(`there is more than one target version expression specified for name %q and tag %q. `+
+			`A solution might be to combine the target version expressions by using a range, for example: `+
+			`targetVersion: ">= 1.18, < 1.22"`,
 			res2.Name, tag)
 	}
 

--- a/pkg/imagevector_test.go
+++ b/pkg/imagevector_test.go
@@ -232,6 +232,19 @@ var _ = Describe("Add", func() {
 		}))
 	})
 
+	It("should throw an error in case of different target version labels for the same name and tag", func() {
+		ivReader, err := os.Open("./testdata/resources/12-multi-targetversion-same-name-and-tag.yaml")
+		Expect(err).ToNot(HaveOccurred())
+		defer func() {
+			Expect(ivReader.Close()).ToNot(HaveOccurred())
+		}()
+
+		cd := readComponentDescriptor("./testdata/00-component/component-descriptor.yaml")
+
+		err = pkg.ParseImageVector(context.TODO(), nil, cd, ivReader, &pkg.ParseImageOptions{})
+		Expect(err).To(HaveOccurred())
+	})
+
 	Context("ComponentReferences", func() {
 
 		Context("should add image sources that match a given pattern as component reference", func() {

--- a/pkg/testdata/resources/12-multi-targetversion-same-name-and-tag.yaml
+++ b/pkg/testdata/resources/12-multi-targetversion-same-name-and-tag.yaml
@@ -1,0 +1,11 @@
+images:
+  - name: metrics-server
+    sourceRepository: github.com/kubernetes-incubator/metrics-server
+    repository: k8s.gcr.io/metrics-server/metrics-server
+    tag: v0.4.1
+    targetVersion: 1.10.x
+  - name: metrics-server
+    sourceRepository: github.com/kubernetes-incubator/metrics-server
+    repository: k8s.gcr.io/metrics-server/metrics-server
+    tag: v0.4.1
+    targetVersion: 1.11.x


### PR DESCRIPTION
**What this PR does / why we need it**:
Function `ParseImageVector` adds the entries of an images.yaml file to a component descriptor. Currently, if two image entries have the same name and tag, but different target versions, only one of the target versions is added to the component descriptor; but the other one gets lost.

This pull request introduces a check that throws an error if this case occurs.

Example of the unsupported case (same name and tag, different target version):

```yaml
images:
- name: cloud-controller-manager
  sourceRepository: github.com/kubernetes/cloud-provider-openstack
  repository: k8scloudprovider/openstack-cloud-controller-manager
  tag: "v1.21.0"
  targetVersion: "1.19.x"
- name: cloud-controller-manager
  sourceRepository: github.com/kubernetes/cloud-provider-openstack
  repository: k8scloudprovider/openstack-cloud-controller-manager
  tag: "v1.21.0"
  targetVersion: "1.20.x"
```

For all known images.yaml files it has sufficed to combine multiple entries with same name and tag into a single entry with a range of target versions, for example:

```yaml
targetVersion: ">= 1.19, < 1.21"
```


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
NONE
```
